### PR TITLE
updated link to pystorms webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ performance = env.performance()
 
 ```
 
-Detailed documentation can be found on the [webpage](https://klabum.github.io/pystorms/)
+Detailed documentation can be found on the [webpage](https://www.pystorms.org)


### PR DESCRIPTION
Updated link to pystorms webpage. Hopefully this is the right url (wasn't sure if this one or the one directly to the documentation page would be better).